### PR TITLE
Fix += overload

### DIFF
--- a/src/Listener.swift
+++ b/src/Listener.swift
@@ -1,5 +1,5 @@
 
-public func += (var storage: [Listener], listener: Listener) {
+public func += (inout storage: [Listener], listener: Listener) {
   storage.append(listener)
 }
 


### PR DESCRIPTION
## Before
- `+=` is not working
- After this function has been finished, `storage` is released
## After
- `+=` is working!
- I can ratain `storage` from outside the this function
