### PR TITLE
Fixes build warnings

### DIFF
--- a/src/ChangeListener.swift
+++ b/src/ChangeListener.swift
@@ -121,7 +121,7 @@ class ChangeObserver : NSObject {
   
   let handler: NSDictionary -> Void
   
-  override func observeValueForKeyPath (keyPath: String!, ofObject object: AnyObject!, change: [NSObject : AnyObject]!, context: UnsafeMutablePointer<Void>) {
+  override func observeValueForKeyPath (keyPath: String, ofObject object: AnyObject, change: [NSObject : AnyObject], context: UnsafeMutablePointer<Void>) {
     handler(change ?? [:])
   }
   


### PR DESCRIPTION
This commit should remove warnings when building src/ChangeListener.swift

Signature: https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Protocols/NSKeyValueObserving_Protocol/#//apple_ref/occ/instm/NSObject/observeValueForKeyPath:ofObject:change:context: