### PR TITLE
Add umbrella header

### DIFF
--- a/EmitterKit.xcodeproj/project.pbxproj
+++ b/EmitterKit.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		117CC8A619CC37ED00A57695 /* Signal.swift in Headers */ = {isa = PBXBuildFile; fileRef = 11FCD69219CA175C006B6D44 /* Signal.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		11F4760E19CC1DA500831EE5 /* Helpers.swift in Headers */ = {isa = PBXBuildFile; fileRef = 11F4760D19CC1DA500831EE5 /* Helpers.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		11FCD69319CA175C006B6D44 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FCD69219CA175C006B6D44 /* Signal.swift */; };
+		CEB7AFFD1B11F01D007888F7 /* EmitterKit.h in Headers */ = {isa = PBXBuildFile; fileRef = CEB7AFFC1B11F01D007888F7 /* EmitterKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		116AB9EF19D1DC5D000AE06F /* EmitterKitTests.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = EmitterKitTests.xcodeproj; path = tests/EmitterKitTests.xcodeproj; sourceTree = "<group>"; };
 		11F4760D19CC1DA500831EE5 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		11FCD69219CA175C006B6D44 /* Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
+		CEB7AFFC1B11F01D007888F7 /* EmitterKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmitterKit.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +116,7 @@
 		115F4CB819BEA04E00595510 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				CEB7AFFC1B11F01D007888F7 /* EmitterKit.h */,
 				11F4760F19CC211600831EE5 /* Helpers */,
 				1102853E19C9D5FE0069F253 /* Emitter */,
 				1102853D19C9D5F90069F253 /* Listener */,
@@ -144,6 +147,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEB7AFFD1B11F01D007888F7 /* EmitterKit.h in Headers */,
 				11F4760E19CC1DA500831EE5 /* Helpers.swift in Headers */,
 				1172DFFB19C9EBCA005A84EA /* Emitter.swift in Headers */,
 				1172DFFD19C9EBCA005A84EA /* Event.swift in Headers */,

--- a/src/EmitterKit.h
+++ b/src/EmitterKit.h
@@ -1,0 +1,19 @@
+//
+//  EmitterKit.h
+//  EmitterKit
+//
+//  Created by Dominique d'Argent on 24/05/15.
+//  Copyright (c) 2015 Alec Larson. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for EmitterKit.
+FOUNDATION_EXPORT double EmitterKitVersionNumber;
+
+//! Project version string for EmitterKit.
+FOUNDATION_EXPORT const unsigned char EmitterKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <EmitterKit/PublicHeader.h>
+
+


### PR DESCRIPTION
Hi,
this PR adds an umbrella header, which fixes a build warning (see below).

![Warning: no umbrella header found for target 'EmitterKit', module map will not be generated](https://cloud.githubusercontent.com/assets/118781/7787731/7a0fd632-021b-11e5-85d9-b6d360eb0c77.png)
> Warning: no umbrella header found for target 'EmitterKit', module map will not be generated
