### PR TITLE
Replace `extern` with `FOUNDATION_EXPORT`

### DIFF
--- a/src/EmitterKit.h
+++ b/src/EmitterKit.h
@@ -1,2 +1,4 @@
-extern double EmitterKitVersionNumber;
-extern const unsigned char EmitterKitVersionString[];
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT double EmitterKitVersionNumber;
+FOUNDATION_EXPORT const unsigned char EmitterKitVersionString[];


### PR DESCRIPTION
This is the standard way of defining an umbrella header. Just don't remove the Foundation import, again!