### PR TITLE
Add headers to podspec source files

### DIFF
--- a/EmitterKit.podspec
+++ b/EmitterKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
 
-  s.source_files = 'src/*.swift'
+  s.source_files = 'src/*.{h,swift}'
 
   s.requires_arc = true
 end


### PR DESCRIPTION
This makes the umbrella header visible to CocoaPods builds.