### PR TITLE
Add @warn_unused_result on methods which return Listener Fix #27

### DIFF
--- a/src/ChangeListener.swift
+++ b/src/ChangeListener.swift
@@ -4,21 +4,25 @@ import Foundation
 extension NSObject {
 
   /// Creates a Listener for key-value observing.
+  @warn_unused_result
   public func on <T:Any> (keyPath: String, _ handler: Change<T> -> Void) -> Listener {
     return on(keyPath, [.Old, .New], handler)
   }
 
   /// Creates a single-use Listener for key-value observing.
+  @warn_unused_result
   public func once <T:Any> (keyPath: String, _ handler: Change<T> -> Void) -> Listener {
     return once(keyPath, [.Old, .New], handler)
   }
   
   /// Creates a Listener for key-value observing.
+  @warn_unused_result
   public func on <T:Any> (keyPath: String, _ options: NSKeyValueObservingOptions, _ handler: Change<T> -> Void) -> Listener {
     return ChangeListener(false, self, keyPath, options, handler)
   }
   
   /// Creates a single-use Listener for key-value observing.
+  @warn_unused_result
   public func once <T:Any> (keyPath: String, _ options: NSKeyValueObservingOptions, _ handler: Change<T> -> Void) -> Listener {
     return ChangeListener(true, self, keyPath, options, handler)
   }

--- a/src/Event.swift
+++ b/src/Event.swift
@@ -1,18 +1,22 @@
 
 public class Event <EventData: Any> : Emitter {
 
+  @warn_unused_result
   public func on (handler: EventData -> Void) -> Listener {
     return EmitterListener(self, nil, castData(handler), false)
   }
   
+  @warn_unused_result
   public func on (target: AnyObject, _ handler: EventData -> Void) -> Listener {
     return EmitterListener(self, target, castData(handler), false)
   }
   
+  @warn_unused_result
   public func once (handler: EventData -> Void) -> Listener {
     return EmitterListener(self, nil, castData(handler), true)
   }
   
+  @warn_unused_result
   public func once (target: AnyObject, _ handler: EventData -> Void) -> Listener {
     return EmitterListener(self, target, castData(handler), true)
   }

--- a/src/Notification.swift
+++ b/src/Notification.swift
@@ -10,21 +10,25 @@ public class Notification {
   }
 
   /// Creates a Listener for an NSNotification.
+  @warn_unused_result
   public func on (handler: NSDictionary -> Void) -> Listener {
     return NotificationListener(name, nil, handler, false)
   }
 
   /// Creates a Listener for an NSNotification with the given target.
+  @warn_unused_result
   public func on (target: AnyObject!, _ handler: NSDictionary -> Void) -> Listener {
     return NotificationListener(name, target, handler, false)
   }
 
   /// Creates a single-use Listener for an NSNotification.
+  @warn_unused_result
   public func once (handler: NSDictionary -> Void) -> Listener {
     return NotificationListener(name, nil, handler, true)
   }
 
   /// Creates a single-use Listener for an NSNotification with the given target.
+  @warn_unused_result
   public func once (target: AnyObject!, _ handler: NSDictionary -> Void) -> Listener {
     return NotificationListener(name, target, handler, true)
   }

--- a/src/Signal.swift
+++ b/src/Signal.swift
@@ -1,18 +1,22 @@
 
 public class Signal : Emitter {
 
+  @warn_unused_result
   public func on (handler: Void -> Void) -> Listener {
     return EmitterListener(self, nil, { _ in handler() }, false)
   }
   
+  @warn_unused_result
   public func on (target: AnyObject, _ handler: Void -> Void) -> Listener {
     return EmitterListener(self, target, { _ in handler() }, false)
   }
   
+  @warn_unused_result
   public func once (handler: Void -> Void) -> Listener {
     return EmitterListener(self, nil, { _ in handler() }, true)
   }
   
+  @warn_unused_result
   public func once (target: AnyObject, _ handler: Void -> Void) -> Listener {
     return EmitterListener(self, target, { _ in handler() }, true)
   }


### PR DESCRIPTION
Warn user of framework to keep a reference on `Listener` objects
see #27