### PR TITLE
Check “Allow app extension API only”

### DIFF
--- a/EmitterKit.xcodeproj/project.pbxproj
+++ b/EmitterKit.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		1102852619C9BCEB0069F253 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -335,6 +336,7 @@
 		1102852719C9BCEB0069F253 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
Check “Allow app extension API only” in Project > General > Deployment Info, to avoid a linker warning when using EmitterKit within an app extension. Otherwise Apple may reject the app.

https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html