### PR TITLE
Fix NotificationListenerTests testOnce

### DIFF
--- a/tests/NotificationListenerTests.swift
+++ b/tests/NotificationListenerTests.swift
@@ -18,7 +18,7 @@ class NotificationListenerTests: XCTestCase {
 
   func testOnce () {
     listener = event.once {
-      XCTAssertNotNil($0["test"], "NotificationListener failed to receive intact NSDictionary")
+      XCTAssertNotNil($0.userInfo!["test"], "NotificationListener failed to receive intact NSDictionary")
       self.calls += 1
     }
 


### PR DESCRIPTION
Tests have stopped compiling after change NSDicitonary to Notification in  Notifier once method