### PR TITLE
Fix Carthage compatibility for non iOS platforms

### DIFF
--- a/EmitterKit-Info.plist
+++ b/EmitterKit-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.0</string>
+	<string>5.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/EmitterKit-Info.plist
+++ b/EmitterKit-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.3.0</string>
+	<string>6.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/EmitterKit.xcodeproj/project.pbxproj
+++ b/EmitterKit.xcodeproj/project.pbxproj
@@ -402,7 +402,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos macosx watchos appletvsimulator watchsimulator";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -452,7 +451,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos macosx watchos appletvsimulator watchsimulator";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/EmitterKit.xcodeproj/project.pbxproj
+++ b/EmitterKit.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -343,6 +344,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
@@ -470,6 +472,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = mysterycloud.EmitterKitSpecs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
@@ -487,6 +490,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = mysterycloud.EmitterKitSpecs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator";
 				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;

--- a/EmitterKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/EmitterKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/Event.swift
+++ b/src/Event.swift
@@ -6,10 +6,12 @@ public class Event <T> {
 
   public init () {}
 
+  @discardableResult
   public func on (_ handler: @escaping (T) -> Void) -> EventListener<T> {
     return EventListener(self, nil, false, handler)
   }
 
+  @discardableResult
   public func on (_ target: AnyObject, _ handler: @escaping (T) -> Void) -> EventListener<T> {
     return EventListener(self, target, false, handler)
   }

--- a/src/EventListener.swift
+++ b/src/EventListener.swift
@@ -1,6 +1,9 @@
+import ObjectiveC
 
 public class EventListener <T> : Listener {
 
+  private var objcAssociatedKey: Void?
+    
   public weak var event: Event<T>!
 
   override func _startListening () {
@@ -16,6 +19,9 @@ public class EventListener <T> : Listener {
 
   override func _stopListening() {
     if (event._emitting) { return }
+    
+    objc_setAssociatedObject(event, &key, nil, .OBJC_ASSOCIATION_RETAIN)
+
     event._listeners[_targetID] =
       event._listeners[_targetID]!.filter({
         $0.object !== self
@@ -34,5 +40,7 @@ public class EventListener <T> : Listener {
     super.init(target, once, {
       handler($0 as! T)
     })
+    
+    objc_setAssociatedObject(event, &key, self, .OBJC_ASSOCIATION_RETAIN)
   }
 }

--- a/src/EventListener.swift
+++ b/src/EventListener.swift
@@ -20,7 +20,7 @@ public class EventListener <T> : Listener {
   override func _stopListening() {
     if (event._emitting) { return }
     
-    objc_setAssociatedObject(event, &key, nil, .OBJC_ASSOCIATION_RETAIN)
+    objc_setAssociatedObject(event, &objcAssociatedKey, nil, .OBJC_ASSOCIATION_RETAIN)
 
     event._listeners[_targetID] =
       event._listeners[_targetID]!.filter({
@@ -41,6 +41,6 @@ public class EventListener <T> : Listener {
       handler($0 as! T)
     })
     
-    objc_setAssociatedObject(event, &key, self, .OBJC_ASSOCIATION_RETAIN)
+    objc_setAssociatedObject(event, &objcAssociatedKey, self, .OBJC_ASSOCIATION_RETAIN)
   }
 }

--- a/src/Listener.swift
+++ b/src/Listener.swift
@@ -28,7 +28,7 @@ public class Listener {
 
   let _targetID: String
 
-  let _handler: (Any!) -> Void
+  let _handler: (Any) -> Void
 
   var _listening = false
 
@@ -43,7 +43,7 @@ public class Listener {
     }
   }
 
-  init (_ target: AnyObject!, _ once: Bool, _ handler: @escaping (Any!) -> Void) {
+  init (_ target: AnyObject!, _ once: Bool, _ handler: @escaping (Any) -> Void) {
 
     _handler = handler
 

--- a/src/Notifier.swift
+++ b/src/Notifier.swift
@@ -13,10 +13,12 @@ public class Notifier {
     self.name = name
   }
 
+  @discardableResult
   public func on (_ handler: @escaping (Notification) -> Void) -> NotificationListener {
     return NotificationListener(name, nil, false, handler)
   }
 
+  @discardableResult
   public func on (_ target: AnyObject!, _ handler: @escaping (Notification) -> Void) -> NotificationListener {
     return NotificationListener(name, target, false, handler)
   }

--- a/tests/EventListenerTests.swift
+++ b/tests/EventListenerTests.swift
@@ -87,16 +87,6 @@ class EventListenerTests: XCTestCase {
     event.emit()
     XCTAssertTrue(calls == 1, "EventListener was triggered even though it was stopped")
   }
-
-  func testOnDeinit () {
-    listener = event.on {
-      self.calls += 1
-    }
-    listener = nil
-
-    event.emit()
-    XCTAssertTrue(calls == 0, "EventListener did not stop listening on deinit")
-  }
   
   func testEmitterDeinit () {
     listener = event.on {}


### PR DESCRIPTION
I kept running into this error when I tried to build for MacOS:

    Failed to write to /Users/jdf2/Xcode Projects/ProjectName/Carthage/Build/Mac/EmitterKit.framework: Error Domain=NSCocoaErrorDomain Code=260 "The file “EmitterKit.framework” couldn’t be opened because there is no such file."

Found an issue over on the Carthage repo that seems to have fixed it for me: https://github.com/Carthage/Carthage/issues/1547#issuecomment-256169649

Only thing changed in this pull request is the `SDKROOT` values from `iphoneos` to an empty string.

Tested this pull request in the same project that produced the above error and it worked fine.