### PR TITLE
Fix Carthage compatibility for non iOS platforms (2)

### DIFF
--- a/EmitterKit-Info.plist
+++ b/EmitterKit-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.0</string>
+	<string>5.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/EmitterKit.podspec
+++ b/EmitterKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'EmitterKit'
-  s.version = '5.2.0'
+  s.version = '5.2.1'
   s.license = 'MIT'
   s.summary = 'Type-safe event handling for Swift'
   s.homepage = 'https://github.com/aleclarson/emitter-kit'

--- a/EmitterKit.xcodeproj/project.pbxproj
+++ b/EmitterKit.xcodeproj/project.pbxproj
@@ -400,7 +400,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos macosx watchos appletvsimulator watchsimulator";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -450,7 +449,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos macosx watchos appletvsimulator watchsimulator";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# emitter-kit v5.2.0
+# emitter-kit v5.2.1
 
 ![stable](https://img.shields.io/badge/stability-stable-4EBA0F.svg?style=flat)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/EmitterKit.svg?style=flat)](https://cocoapods.org/pods/EmitterKit)
@@ -80,6 +80,9 @@ listener = view.on("bounds") { (change: Change<CGRect>) in
   print(change)
 }
 ```
+### v5.2.1 changelog
+
+- Fix Carthage compatibility for non iOS platforms
 
 ### v5.2.0 changelog
 
@@ -121,4 +124,3 @@ listener = view.on("bounds") { (change: Change<CGRect>) in
 - An `event: Event<T>` property was added to the `EventListener<T>` class.
 
 The changelog for older versions can be [found here](https://github.com/aleclarson/emitter-kit/wiki/Changelog).
-


### PR DESCRIPTION
I kept running into this error when I tried to build for MacOS:

Failed to write to /Users/jdf2/Xcode Projects/ProjectName/Carthage/Build/Mac/EmitterKit.framework: Error Domain=NSCocoaErrorDomain Code=260 "The file “EmitterKit.framework” couldn’t be opened because there is no such file."
Found an issue over on the Carthage repo that seems to have fixed it for me: Carthage/Carthage#1547 (comment)

Only thing changed in this pull request is to remove SDKROOT value as suggested by cartage issue (https://github.com/Carthage/Carthage/issues/1547)

Tested this pull request in the same project that produced the above error and it worked fine.

PS content of this PR is inspired in PR #53 but instead of committing other improvements, only adds what it says above.